### PR TITLE
prevent labels in page reference fields

### DIFF
--- a/PageHitCounter.module
+++ b/PageHitCounter.module
@@ -456,7 +456,7 @@ class PageHitCounter extends WireData implements Module, ConfigurableModule {
             // ------------------------------------------------------------------------
             // Show counter in page tree
             // ------------------------------------------------------------------------
-            if($this->showForBackend) {
+            if($this->showForBackend AND $this->wire->input->get('mode') != 'select') {
                 $this->addHookAfter('ProcessPageListRender::getPageLabel', $this, 'addPageListHitCounter');
                 wire('config')->styles->add($this->config->urls->PageHitCounter . 'PageHitCounter.min.css');
             }


### PR DESCRIPTION
Idea by zeka https://processwire.com/talk/topic/25518-how-to-prevent-hook-processpagelistrendergetpagelabel-in-pagelistselect-field/?do=findComment&comment=213786

Here is the issue that it solves:

https://processwire.com/talk/topic/25518-how-to-prevent-hook-processpagelistrendergetpagelabel-in-pagelistselect-field/